### PR TITLE
Add cache-control headers to __about

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function(app, options) {
 
 	if (opts.routes.indexOf('about') !== -1) {
 		app.get(/^\/__about$/, function(req, res) {
+			res.set('Cache-Control', 'no-store');
 			res.json(opts.about || {});
 		});
 	}


### PR DESCRIPTION
We just spent 10 minutes trying to work out why AMP prod was an old version despite being recently deployed. It was because Akamai cached the __about endpoint...