### PR TITLE
Support Restify

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Running Express Web Service requires [Node.js] 6.x and [npm]. You can install wi
 npm install @financial-times/express-web-service
 ```
 
+You'll also need to be using [Express] 4+. Express Web Service also supports [Restify] with a few modifications, see [the examples](#examples) for more information.
+
 ### API Documentation
 
 Familiarity with [Express] is assumed in the rest of the API documentation. You'll also need to require the module with:
@@ -147,6 +149,21 @@ app.use(expressWebService({
 }));
 ```
 
+Example of using with [Restify] rather than Express:
+
+```js
+const expressWebService = require('@financial-times/express-web-service');
+const restify = require('restify');
+
+const server = restify.createServer();
+
+// Because Restify doesn't mount middleware for routes that don't exist,
+// we have to explicitly define the required routes
+server.get(/^\/__(about|gtg|health)$/, expressWebService({
+	// config
+}));
+```
+
 
 Migration
 ---------
@@ -224,3 +241,4 @@ This software is published by the Financial Times under the [MIT licence][licens
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [origami support]: mailto:origami-support@ft.com
+[restify]: http://restify.com/

--- a/lib/express-web-service.js
+++ b/lib/express-web-service.js
@@ -41,7 +41,11 @@ function expressWebService(options) {
 	// Main middleware function, routes to each of the
 	// individual middleware below
 	function middleware(request, response, next) {
-		switch (request.path) {
+		let path = request.path;
+		if (typeof request.path === 'function') {
+			path = request.path();
+		}
+		switch (path) {
 			case '/__about':
 				middleware.about(request, response, next);
 				break;
@@ -65,10 +69,9 @@ function expressWebService(options) {
 		if (!options.routes.includes('about')) {
 			return next();
 		}
-		response
-			.status(200)
-			.set('Cache-Control', options.cacheControl)
-			.send(options.about);
+		response.status(200);
+		response.set('Cache-Control', options.cacheControl);
+		response.send(options.about);
 	};
 
 	// Serve the __error endpoint
@@ -102,18 +105,16 @@ function expressWebService(options) {
 			if (!status) {
 				throw new Error('Not OK, see /__health endpoint');
 			}
-			response
-				.status(200)
-				.set('Cache-Control', options.cacheControl)
-				.set('Content-Type', 'text/plain; charset=utf-8')
-				.send('OK');
+			response.status(200);
+			response.set('Cache-Control', options.cacheControl);
+			response.set('Content-Type', 'text/plain; charset=utf-8');
+			response.send('OK');
 		})
 		.catch(error => {
 			clearTimeout(goodToGoTimeout);
-			response
-				.status(503)
-				.set('Content-Type', 'text/plain; charset=utf-8')
-				.send(error.message);
+			response.status(503);
+			response.set('Content-Type', 'text/plain; charset=utf-8');
+			response.send(error.message);
 		});
 	};
 
@@ -124,22 +125,20 @@ function expressWebService(options) {
 		}
 		return options.healthCheck()
 			.then(checks => {
-				response
-					.status(200)
-					.set('Cache-Control', options.cacheControl)
-					.send({
-						schemaVersion: 1,
-						name: options.about.name,
-						systemCode: options.about.systemCode,
-						description: options.about.purpose,
-						checks: checks
-					});
+				response.status(200);
+				response.set('Cache-Control', options.cacheControl);
+				response.send({
+					schemaVersion: 1,
+					name: options.about.name,
+					systemCode: options.about.systemCode,
+					description: options.about.purpose,
+					checks: checks
+				});
 			})
 			.catch(error => {
-				response
-					.status(500)
-					.set('Content-Type', 'text/plain; charset=utf-8')
-					.send(error.message);
+				response.status(500);
+				response.set('Content-Type', 'text/plain; charset=utf-8');
+				response.send(error.message);
 			});
 	};
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "npm-prepublish": "^1.2.2",
     "nyc": "^10.0.0",
     "proclaim": "^3.4.4",
+    "restify": "^6.3.2",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2",
     "supertest": "^2.0.0"

--- a/test/integration/express.js
+++ b/test/integration/express.js
@@ -6,26 +6,26 @@ const request = require('supertest');
 describe('ft-express-web-service', function() {
 
 	it('has a /__gtg endpoint which returns a text document with a 200', function() {
-		return request(this.app)
+		return request(this.expressApp)
 			.get('/__gtg')
 			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
-			.expect('Content-Type', 'text/plain; charset=utf-8')
+			.expect('Content-Type', /text\/plain/i)
 			.expect(200);
 	});
 
 	it('has a /__health endpoint which returns JSON with a 200 which follows the schema', function() {
-		return request(this.app)
+		return request(this.expressApp)
 			.get('/__health')
 			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
-			.expect('Content-Type', 'application/json; charset=utf-8')
+			.expect('Content-Type', /application\/json/i)
 			.expect(200);
 	});
 
 	it('has a /__about endpoint which returns JSON with a 200', function() {
-		return request(this.app)
+		return request(this.expressApp)
 			.get('/__about')
 			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
-			.expect('Content-Type', 'application/json; charset=utf-8')
+			.expect('Content-Type', /application\/json/i)
 			.expect(response => {
 				assert.strictEqual(response.body.foo, 'bar');
 				assert.strictEqual(response.body._hostname, require('os').hostname());
@@ -36,9 +36,9 @@ describe('ft-express-web-service', function() {
 	});
 
 	it('has a /__error endpoint which returns an error message with a 500', function() {
-		return request(this.app)
+		return request(this.expressApp)
 			.get('/__error')
-			.expect('Content-Type', 'text/html; charset=utf-8')
+			.expect('Content-Type', /text\/html/i)
 			.expect(500);
 	});
 

--- a/test/integration/restify.js
+++ b/test/integration/restify.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('proclaim');
+const request = require('supertest');
+
+describe('ft-express-web-service', function() {
+
+	it('has a /__gtg endpoint which returns a text document with a 200', function() {
+		return request(this.restifyApp)
+			.get('/__gtg')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Content-Type', /text\/plain/i)
+			.expect(200);
+	});
+
+	it('has a /__health endpoint which returns JSON with a 200 which follows the schema', function() {
+		return request(this.restifyApp)
+			.get('/__health')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Content-Type', /application\/json/i)
+			.expect(200);
+	});
+
+	it('has a /__about endpoint which returns JSON with a 200', function() {
+		return request(this.restifyApp)
+			.get('/__about')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Content-Type', /application\/json/i)
+			.expect(response => {
+				assert.strictEqual(response.body.foo, 'bar');
+				assert.strictEqual(response.body._hostname, require('os').hostname());
+				assert.strictEqual(response.body.appVersion, '1.2.3');
+				assert.match(response.body.dateDeployed, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}/);
+			})
+			.expect(200);
+	});
+
+});

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -2,10 +2,12 @@
 
 const express = require('express');
 const expressWebService = require('../..');
+const restify = require('restify');
 
 before(function(done) {
-	this.app = express();
-	this.app.use(expressWebService({
+
+	this.expressApp = express();
+	this.expressApp.use(expressWebService({
 		about: {
 			foo: 'bar'
 		},
@@ -17,9 +19,26 @@ before(function(done) {
 			'health'
 		]
 	}));
-	this.server = this.app.listen(done);
+
+	this.restifyApp = restify.createServer();
+	this.restifyApp.get(/^\/__(about|gtg|health)$/, expressWebService({
+		about: {
+			foo: 'bar'
+		},
+		manifestPath: `${__dirname}/mock-manifest.json`,
+		routes: [
+			'about',
+			'gtg',
+			'health'
+		]
+	}));
+
+	this.expressServer = this.expressApp.listen(() => {
+		this.restifyServer = this.restifyApp.listen(done);
+	});
 });
 
 after(function() {
-	this.server.close();
+	this.expressServer.close();
+	this.restifyServer.close();
 });

--- a/test/unit/lib/express-web-service.js
+++ b/test/unit/lib/express-web-service.js
@@ -217,6 +217,29 @@ describe('lib/express-web-service', () => {
 
 			});
 
+			describe('when `request.path` is a function (Restify API)', () => {
+
+				beforeEach(() => {
+					next.reset();
+					express.mockRequest.path = sinon.stub().returns('/__about');
+					middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('calls `request.path`', () => {
+					assert.calledOnce(express.mockRequest.path);
+				});
+
+				it('still calls the expected middleware function', () => {
+					assert.calledOnce(middleware.about);
+					assert.calledWithExactly(middleware.about, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('does not call `next`', () => {
+					assert.notCalled(next);
+				});
+
+			});
+
 		});
 
 		describe('middleware.about(request, response, next)', () => {


### PR DESCRIPTION
The Ads team are using Restify for some of their services, this has a
very similar API to Express and only a few small tweaks are needed to
this library in order for it to work.

I think this is worth doing to get the library used across more of the
FT. I've done the appropriate work and we're also testing against
Restify to ensure it works in future.

@anupamabalahara perhaps you'd like to take a look too?