### PR TITLE
Add private cache-control directive to avoid being cached by middleboxes

### DIFF
--- a/lib/express-web-service.js
+++ b/lib/express-web-service.js
@@ -9,7 +9,7 @@ module.exports = expressWebService;
 
 module.exports.defaults = {
 	about: {},
-	cacheControl: 'max-age=0, must-revalidate, no-cache, no-store',
+	cacheControl: 'max-age=0, must-revalidate, no-cache, no-store, private',
 	goodToGoTest: () => Promise.resolve(true),
 	healthCheck: () => Promise.resolve([ { ok: true } ]),
 	manifestPath: path.join(process.cwd(), 'package.json'),

--- a/test/integration/express.test.js
+++ b/test/integration/express.test.js
@@ -8,7 +8,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__gtg endpoint which returns a text document with a 200', function() {
 		return request(this.expressApp)
 			.get('/__gtg')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /text\/plain/i)
 			.expect(200);
 	});
@@ -16,7 +16,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__health endpoint which returns JSON with a 200 which follows the schema', function() {
 		return request(this.expressApp)
 			.get('/__health')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /application\/json/i)
 			.expect(200);
 	});
@@ -24,7 +24,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__about endpoint which returns JSON with a 200', function() {
 		return request(this.expressApp)
 			.get('/__about')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /application\/json/i)
 			.expect(response => {
 				assert.strictEqual(response.body.foo, 'bar');

--- a/test/integration/restify.test.js
+++ b/test/integration/restify.test.js
@@ -8,7 +8,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__gtg endpoint which returns a text document with a 200', function() {
 		return request(this.restifyApp)
 			.get('/__gtg')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /text\/plain/i)
 			.expect(200);
 	});
@@ -16,7 +16,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__health endpoint which returns JSON with a 200 which follows the schema', function() {
 		return request(this.restifyApp)
 			.get('/__health')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /application\/json/i)
 			.expect(200);
 	});
@@ -24,7 +24,7 @@ describe('ft-express-web-service', function() {
 	it('has a /__about endpoint which returns JSON with a 200', function() {
 		return request(this.restifyApp)
 			.get('/__about')
-			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store')
+			.expect('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private')
 			.expect('Content-Type', /application\/json/i)
 			.expect(response => {
 				assert.strictEqual(response.body.foo, 'bar');

--- a/test/unit/lib/express-web-service.test.js
+++ b/test/unit/lib/express-web-service.test.js
@@ -48,7 +48,7 @@ describe('lib/express-web-service', () => {
 		});
 
 		it('has a `cacheControl` property', () => {
-			assert.deepEqual(expressWebService.defaults.cacheControl, 'max-age=0, must-revalidate, no-cache, no-store');
+			assert.deepEqual(expressWebService.defaults.cacheControl, 'max-age=0, must-revalidate, no-cache, no-store, private');
 		});
 
 		it('has a `goodToGoTest` property', () => {


### PR DESCRIPTION
CDN providers may do request collapsing if the response is deemed cacheable. Setting the cache control directive `private` mean this is not cacheable and request collapsing should never be used.  